### PR TITLE
Postprocessing update

### DIFF
--- a/pennylane/kernels/__init__.py
+++ b/pennylane/kernels/__init__.py
@@ -29,6 +29,7 @@ from .cost_functions import (
 from .postprocessing import (
     threshold_matrix,
     displace_matrix,
+    flip_matrix,
     closest_psd_matrix,
     mitigate_depolarizing_noise,
 )

--- a/pennylane/kernels/__init__.py
+++ b/pennylane/kernels/__init__.py
@@ -20,9 +20,15 @@ This subpackage defines functions that relate to quantum kernel methods.
 """
 from .embedding_kernel import EmbeddingKernel
 from .cost_functions import (
+    matrix_inner_product,
     kernel_polarization,
     kernel_target_alignment,
     kernel_matrix,
     square_kernel_matrix,
 )
-from .postprocessing import threshold_matrix, displace_matrix
+from .postprocessing import (
+    threshold_matrix,
+    displace_matrix,
+    closest_psd_matrix,
+    mitigate_depolarizing_noise,
+)

--- a/pennylane/kernels/cost_functions.py
+++ b/pennylane/kernels/cost_functions.py
@@ -18,17 +18,21 @@ See 10.1007/s10462-012-9369-4 for a review.
 from pennylane import numpy as np
 
 
-def _matrix_inner_product(A, B):
+def matrix_inner_product(A, B, normalize=False):
     """Frobenius/Hilbert-Schmidt inner product between two matrices
 
     Args:
         A (array[float]): First matrix, assumed to be a square array.
         B (array[float]): Second matrix, assumed to be a square array.
+        normalize (bool): If True, divide the inner_product by the Frobenius norms of A&B
 
     Returns:
         float: Inner product of A and B
     """
-    return np.trace(np.dot(np.transpose(A), B))
+    inner_product = np.trace(np.dot(np.transpose(A), B))
+    if normalize:
+        inner_product /= np.linalg.norm(A, "fro") * np.linalg.norm(B, "fro")
+    return inner_product
 
 
 def square_kernel_matrix(X, kernel, assume_normalized_kernel=False):
@@ -79,7 +83,14 @@ def kernel_matrix(X1, X2, kernel):
     return np.array(matrix).reshape((N, M))
 
 
-def kernel_polarization(X, Y, kernel, assume_normalized_kernel=False, rescale_class_labels=True):
+def kernel_polarization(
+    X,
+    Y,
+    kernel,
+    assume_normalized_kernel=False,
+    rescale_class_labels=True,
+    normalize=False,
+):
     """Kernel polarization of a given kernel function.
 
     Args:
@@ -90,6 +101,7 @@ def kernel_polarization(X, Y, kernel, assume_normalized_kernel=False, rescale_cl
             that when both arguments are the same datapoint the kernel evaluates to 1. Defaults to False.
         rescale_class_labels (bool, optional): Rescale the class labels. This is important to take
             care of unbalanced datasets. Defaults to True.
+        normalize (bool): If True, rescale the polarization to the kernel_target_alignment.
 
     Returns:
         float: The kernel polarization.
@@ -105,33 +117,9 @@ def kernel_polarization(X, Y, kernel, assume_normalized_kernel=False, rescale_cl
 
     T = np.outer(_Y, _Y)
 
-    return _matrix_inner_product(K, T)
+    return matrix_inner_product(K, T, normalize=normalize)
 
 
-def kernel_target_alignment(
-    X, Y, kernel, assume_normalized_kernel=False, rescale_class_labels=True
-):
-    """Kernel target alignment of a given kernel function.
-
-    Args:
-        X (list[datapoint]): List of datapoints
-        Y (list[float]): List of class labels of datapoints, assumed to be either -1 or 1.
-        kernel ((datapoint, datapoint) -> float): Kernel function that maps datapoints to kernel value.
-        assume_normalized_kernel (bool, optional): Assume that the kernel is normalized, i.e.
-            that when both arguments are the same datapoint the kernel evaluates to 1. Defaults to False.
-
-    Returns:
-        float: The kernel target alignment.
-    """
-    K = square_kernel_matrix(X, kernel, assume_normalized_kernel=assume_normalized_kernel)
-
-    if rescale_class_labels:
-        nplus = np.count_nonzero(np.array(Y) == 1)
-        nminus = len(Y) - nplus
-        _Y = np.array([y / nplus if y == 1 else y / nminus for y in Y])
-    else:
-        _Y = np.array(Y)
-
-    T = np.outer(_Y, _Y)
-
-    return _matrix_inner_product(K, T) / (np.linalg.norm(K, "fro") * np.linalg.norm(T, "fro"))
+kernel_target_alignment = lambda *args, **kwargs: kernel_polarization(
+    *args, normalize=True, **kwargs
+)

--- a/pennylane/kernels/cost_functions.py
+++ b/pennylane/kernels/cost_functions.py
@@ -24,12 +24,12 @@ def matrix_inner_product(A, B, normalize=False):
     Args:
         A (array[float]): First matrix, assumed to be a square array.
         B (array[float]): Second matrix, assumed to be a square array.
-        normalize (bool): If True, divide the inner_product by the Frobenius norms of A&B
+        normalize (bool): If True, divide the inner_product by the Frobenius norms of A and B
 
     Returns:
         float: Inner product of A and B
     """
-    inner_product = np.trace(np.dot(np.transpose(A), B))
+    inner_product = np.sum(A * B)
     if normalize:
         inner_product /= np.linalg.norm(A, "fro") * np.linalg.norm(B, "fro")
     return inner_product
@@ -120,6 +120,20 @@ def kernel_polarization(
     return matrix_inner_product(K, T, normalize=normalize)
 
 
-kernel_target_alignment = lambda *args, **kwargs: kernel_polarization(
-    *args, normalize=True, **kwargs
-)
+def kernel_target_alignment(*args, **kwargs):
+    """Kernel target alignment of a given kernel function.
+
+    Args:
+        X (list[datapoint]): List of datapoints
+        Y (list[float]): List of class labels of datapoints, assumed to be either -1 or 1.
+        kernel ((datapoint, datapoint) -> float): Kernel function that maps datapoints to kernel value.
+        assume_normalized_kernel (bool, optional): Assume that the kernel is normalized, i.e.
+            that when both arguments are the same datapoint the kernel evaluates to 1. Defaults to False.
+        rescale_class_labels (bool, optional): Rescale the class labels. This is important to take
+            care of unbalanced datasets. Defaults to True.
+        normalize (bool): If True, rescale the polarization to the kernel_target_alignment.
+
+    Returns:
+        float: The kernel polarization.
+    """
+    return kernel_polarization(*args, normalize=True, **kwargs)

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -58,19 +58,22 @@ def displace_matrix(K):
     return K
 
 
-def closest_psd_matrix(K, fix_diagonal=True, solver=None):
+def closest_psd_matrix(K, fix_diagonal=True, solver=None, **kwargs):
     """Return the closest positive semidefinite matrix to the given kernel matrix.
 
     Args:
         K (array[float]): Kernel matrix assumed to be symmetric.
         fix_diagonal (bool): Whether to fix the diagonal to 1.
         solver (str, optional): Solver to be used by cvxpy. Defaults to CVXOPT.
+        kwargs (kwarg dict): Passed to cvxpy.Problem.solve()
 
     Returns:
         array[float]: closest positive semidefinite matrix in Frobenius norm.
 
     Comments:
         Requires cvxpy and the used solver (default CVXOPT) to be installed.
+        fix_diagonal=False typically leads to problems in the SDP/solving it.
+            Use `threshold_matrix()` instead.
     """
     if not fix_diagonal:
         wmin = np.min(np.linalg.eigvalsh(K))
@@ -97,14 +100,14 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None):
     problem = cp.Problem(cp.Minimize(objective_fn), constraint)
 
     try:
-        problem.solve(solver=solver)
+        problem.solve(solver=solver, **kwargs)
     except Exception as e:
-        problem.solve(verbose=True, solver=solver)
+        problem.solve(verbose=True, solver=solver, **kwargs)
 
     return X.value
 
 
-def mitigate_depolarization(K, num_wires, method, use_entries=None):
+def mitigate_depolarizing_noise(K, num_wires, method, use_entries=None):
     """Estimate depolarizing noise rate(s) using on the diagonal entries of a kernel
     matrix and mitigate the noise, assuming a global depolarizing noise model.
 

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -72,6 +72,10 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None):
     Comments:
         Requires cvxpy and the used solver (default CVXOPT) to be installed.
     """
+    if not fix_diagonal:
+        wmin = np.min(np.linalg.eigvalsh(K))
+        if wmin >= 0:
+            return K
     try:
         import cvxpy as cp
         if solver is None:
@@ -86,15 +90,8 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None):
             print(" As you don't want to fix the diagonal, using threshold_matrix instead...")
             return threshold_matrix(K)
 
-    if fix_diagonal:
-        constraint = [cp.diag(X) == 1.]
-    else:
-        wmin = np.min(np.linalg.eigvalsh(K))
-        if wmin >= 0:
-            return K
-        constraint = []
-
     X = cp.Variable(K.shape, PSD=True)
+    constraint = [cp.diag(X) == 1.] if fix_diagonal else []
     objective_fn = cp.norm(X - K, "fro")
     problem = cp.Problem(cp.Minimize(objective_fn), constraint)
 

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -115,13 +115,7 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None, **kwargs):
             solver = cp.CVXOPT
     except ImportError:
         # TODO: Make these proper warnings
-        print("CVXPY is required for this post-processing method.", end="")
-        if fix_diagonal:
-            print(" As you want to fix the diagonal, task is impossible. Returning input...")
-            return K
-        else:
-            print(" As you don't want to fix the diagonal, using threshold_matrix instead...")
-            return threshold_matrix(K)
+        raise ImportError("CVXPY is required for this post-processing method.")
 
     X = cp.Variable(K.shape, PSD=True)
     constraint = [cp.diag(X) == 1.0] if fix_diagonal else []

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -114,7 +114,6 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None, **kwargs):
         if solver is None:
             solver = cp.CVXOPT
     except ImportError:
-        # TODO: Make these proper warnings
         print("CVXPY is required for this post-processing method.", end="")
         if fix_diagonal:
             print(" As you want to fix the diagonal, task is impossible. Returning input...")
@@ -130,8 +129,11 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None, **kwargs):
 
     try:
         problem.solve(solver=solver, **kwargs)
-    except Exception as e:
-        problem.solve(verbose=True, solver=solver, **kwargs)
+    except:
+        try:
+            problem.solve(solver=solver, verbose=True, **kwargs)
+        except Exception as e:
+            raise RuntimeError(f"CVXPY solver did not converge.") from e
 
     return X.value
 

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -105,9 +105,7 @@ def closest_psd_matrix(K, fix_diagonal=True, solver=None, **kwargs):
             Use `threshold_matrix()` instead, as it analytically is equivalent.
     """
     if not fix_diagonal:
-        wmin = np.min(np.linalg.eigvalsh(K))
-        if wmin >= 0:
-            return K
+        return threshold_matrix(K)
     try:
         import cvxpy as cp
 

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -130,13 +130,25 @@ class TestHelperFunctions:
         [
             (np.eye(2), np.eye(2), False, 2.0),
             (np.eye(2), np.zeros((2, 2)), False, 0.0),
-            (np.array([[1.0, 2.3], [-1.3, 2.4]]), np.array([[0.7, -7.3], [-1.0, -2.9]]), False, -21.75),
+            (
+                np.array([[1.0, 2.3], [-1.3, 2.4]]),
+                np.array([[0.7, -7.3], [-1.0, -2.9]]),
+                False,
+                -21.75,
+            ),
             (np.eye(2), np.eye(2), True, 1.0),
-            (np.array([[1.0, 2.3], [-1.3, 2.4]]), np.array([[0.7, -7.3], [-1.0, -2.9]]), True, -0.7381450594),
+            (
+                np.array([[1.0, 2.3], [-1.3, 2.4]]),
+                np.array([[0.7, -7.3], [-1.0, -2.9]]),
+                True,
+                -0.7381450594,
+            ),
         ],
     )
     def test_matrix_inner_product(self, A, B, normalize, expected):
-        assert expected == pytest.approx(kern.cost_functions.matrix_inner_product(A, B, normalize=normalize))
+        assert expected == pytest.approx(
+            kern.cost_functions.matrix_inner_product(A, B, normalize=normalize)
+        )
 
 
 class TestKernelMatrix:
@@ -391,7 +403,7 @@ class TestRegularization:
         "input, expected_output",
         [
             (np.diag([1, -1]), np.diag([1, 1])),
-            (np.array([[1, 1], [1, -1]]), np.array([[1., 1.],[1., 1.]])),
+            (np.array([[1, 1], [1, -1]]), np.array([[1.0, 1.0], [1.0, 1.0]])),
             (np.array([[0, 1], [1, 0]]), np.array([[1, 1], [1, 1]])),
         ],
     )
@@ -399,58 +411,79 @@ class TestRegularization:
         output = kern.closest_psd_matrix(input, feastol=1e-10)
         assert np.allclose(output, expected_output, atol=1e-5)
 
+
 def depolarize(mat, rates, num_wires, level):
-    if level=='per_circuit':
-        noisy_mat = (1-rates)*mat+rates/(2**num_wires)*np.ones_like(mat)
-    elif level=='per_embedding':
+    if level == "per_circuit":
+        noisy_mat = (1 - rates) * mat + rates / (2 ** num_wires) * np.ones_like(mat)
+    elif level == "per_embedding":
         noisy_mat = np.copy(mat)
         for i in range(len(mat)):
             for j in range(i, len(mat)):
-                rate = rates[i]+rates[j]-rates[i]*rates[j]
-                noisy_mat[i,j] *= (1-rate)
-                noisy_mat[i,j] += rate/(2**num_wires)
+                rate = rates[i] + rates[j] - rates[i] * rates[j]
+                noisy_mat[i, j] *= 1 - rate
+                noisy_mat[i, j] += rate / (2 ** num_wires)
 
     return noisy_mat
 
+
 class TestMitigation:
     num_wires = 1
-    
+
     @pytest.mark.parametrize(
         "input, use_entry, expected_output",
         [
-            (np.diag([0.9, 0.9]), 0, np.array([[1, -1/8], [-1/8, 1]])),
-            (np.diag([0.9, 0.9]), 1, np.array([[1, -1/8], [-1/8, 1]])),
-            (np.diag([1., 0.9]), 0, np.diag([1, 0.9])),
-            (np.diag([1., 0.9]), 1, np.array([[9/8, -1/8], [-1/8, 1.]])),
-            (depolarize(np.array([[1., 0.5], [0.5, 1.]]), 0.1, num_wires, 'per_circuit'), 0, np.array([[1., 0.5], [0.5, 1.]])),
-            (depolarize(np.array([[1., 0.5], [0.5, 1.]]), 0.1, num_wires, 'per_circuit'), 1, np.array([[1., 0.5], [0.5, 1.]])),
+            (np.diag([0.9, 0.9]), 0, np.array([[1, -1 / 8], [-1 / 8, 1]])),
+            (np.diag([0.9, 0.9]), 1, np.array([[1, -1 / 8], [-1 / 8, 1]])),
+            (np.diag([1.0, 0.9]), 0, np.diag([1, 0.9])),
+            (np.diag([1.0, 0.9]), 1, np.array([[9 / 8, -1 / 8], [-1 / 8, 1.0]])),
+            (
+                depolarize(np.array([[1.0, 0.5], [0.5, 1.0]]), 0.1, num_wires, "per_circuit"),
+                0,
+                np.array([[1.0, 0.5], [0.5, 1.0]]),
+            ),
+            (
+                depolarize(np.array([[1.0, 0.5], [0.5, 1.0]]), 0.1, num_wires, "per_circuit"),
+                1,
+                np.array([[1.0, 0.5], [0.5, 1.0]]),
+            ),
         ],
     )
     def test_mitigate_depolarizing_noise_single(self, input, use_entry, expected_output):
-        output = kern.mitigate_depolarizing_noise(input, self.num_wires, 'single', (use_entry,))
+        output = kern.mitigate_depolarizing_noise(input, self.num_wires, "single", (use_entry,))
         assert np.allclose(output, expected_output)
 
     @pytest.mark.parametrize(
         "input, expected_output",
         [
-            (np.diag([0.9, 0.9]), np.array([[1, -1/8], [-1/8, 1]])),
-            (np.diag([1., 0.9]), np.array([[19/18, -1/18], [-1/18, 17/18]])),
-            (depolarize(np.array([[1., 0.5], [0.5, 1.]]), 0.1, num_wires, 'per_circuit'), np.array([[1., 0.5], [0.5, 1.]])),
+            (np.diag([0.9, 0.9]), np.array([[1, -1 / 8], [-1 / 8, 1]])),
+            (np.diag([1.0, 0.9]), np.array([[19 / 18, -1 / 18], [-1 / 18, 17 / 18]])),
+            (
+                depolarize(np.array([[1.0, 0.5], [0.5, 1.0]]), 0.1, num_wires, "per_circuit"),
+                np.array([[1.0, 0.5], [0.5, 1.0]]),
+            ),
         ],
     )
     def test_mitigate_depolarizing_noise_average(self, input, expected_output):
-        output = kern.mitigate_depolarizing_noise(input, self.num_wires, 'average')
+        output = kern.mitigate_depolarizing_noise(input, self.num_wires, "average")
         assert np.allclose(output, expected_output)
 
     @pytest.mark.parametrize(
         "input, expected_output",
         [
-            (np.diag([0.9, 0.9]), np.array([[1, -1/8], [-1/8, 1]])),
-            (np.diag([1., 0.9]), np.array([[1, -0.059017], [-0.059017, 1.]])),
-            (depolarize(np.array([[1., 0.5], [0.5, 1.]]), 0.1, num_wires, 'per_circuit'), np.array([[1., 0.5], [0.5, 1.]])),
-            (depolarize(np.array([[1., 0.5], [0.5, 1.]]), [0.2, 0.1], num_wires, 'per_embedding'), np.array([[1., 0.5], [0.5, 1.]])),
+            (np.diag([0.9, 0.9]), np.array([[1, -1 / 8], [-1 / 8, 1]])),
+            (np.diag([1.0, 0.9]), np.array([[1, -0.059017], [-0.059017, 1.0]])),
+            (
+                depolarize(np.array([[1.0, 0.5], [0.5, 1.0]]), 0.1, num_wires, "per_circuit"),
+                np.array([[1.0, 0.5], [0.5, 1.0]]),
+            ),
+            (
+                depolarize(
+                    np.array([[1.0, 0.5], [0.5, 1.0]]), [0.2, 0.1], num_wires, "per_embedding"
+                ),
+                np.array([[1.0, 0.5], [0.5, 1.0]]),
+            ),
         ],
     )
     def test_mitigate_depolarizing_noise_split_channel(self, input, expected_output):
-        output = kern.mitigate_depolarizing_noise(input, self.num_wires, 'split_channel')
+        output = kern.mitigate_depolarizing_noise(input, self.num_wires, "split_channel")
         assert np.allclose(output, expected_output)

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -382,7 +382,7 @@ class TestRegularization:
             (np.array([[0, 1], [1, 0]]), np.array([[1, 1], [1, 1]]) / 2.0),
         ],
     )
-    def test_threshold(self, input, expected_output):
+    def test_threshold_matrix(self, input, expected_output):
         assert np.allclose(kern.threshold_matrix(input), expected_output)
 
     @pytest.mark.parametrize(
@@ -396,8 +396,22 @@ class TestRegularization:
             (np.array([[0, 1], [1, 0]]), np.array([[1, 1], [1, 1]])),
         ],
     )
-    def test_displacement(self, input, expected_output):
+    def test_displace_matrix(self, input, expected_output):
         assert np.allclose(kern.displace_matrix(input), expected_output)
+
+    @pytest.mark.parametrize(
+        "input,expected_output",
+        [
+            (np.diag([1, -1]), np.diag([1, 1])),
+            (
+                np.array([[1, 1], [1, -1]]),
+                np.array([[math.sqrt(2), 0], [0, math.sqrt(2)]]),
+            ),
+            (np.array([[0, 1], [1, 0]]), np.array([[1, 0], [0, 1]])),
+        ],
+    )
+    def test_flip_matrix(self, input, expected_output):
+        assert np.allclose(kern.flip_matrix(input), expected_output)
 
     @pytest.mark.parametrize(
         "input, expected_output",

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -408,7 +408,18 @@ class TestRegularization:
         ],
     )
     def test_closest_psd_matrix(self, input, expected_output):
-        output = kern.closest_psd_matrix(input, feastol=1e-10)
+        try:
+            import cvxpy as cp
+            output = kern.closest_psd_matrix(input, feastol=1e-10)
+        except ModuleNotFoundError:
+            pytest.skip("cvxpy seems to not be installed on the system."
+                    "It is required for qml.kernels.closest_psd_matrix"
+                    " and can be installed via `pip install cvxpy`.")
+        except cp.error.SolverError:
+            pytest.skip("The cvxopt solver seems to not be installed on the system."
+                    "It is the default solver for qml.kernels.closest_psd_matrix"
+                    " and can be installed via `pip install cvxopt`.")
+
         assert np.allclose(output, expected_output, atol=1e-5)
 
 


### PR DESCRIPTION
- Reintroduce `closest_psd_matrix`, now including the `fix_diagonal` option that is not captured by `threshold_matrix` (defaults to True).
- Add `normalize` option to `_matrix_inner_product`, which when activated divides the inner product by the Frobenius norms (defaults to False)
- Replaced `kernel_target_alignment` by an alias to `kernel_polarization` using the `normalize` option in `_matrix_inner_product`.
- Expose `_matrix_inner_product` by renaming to `matrix_inner_product` and importing in `__init__.py`
- Change `eigvals` to `eigvalsh` in `displace_matrix` in order to get rid of complex-valued output (The fact that we use the minimum assumes real eigenvalues anyways, this should never restrict the usability of the function).
- Added `postprocessing.py::mitigate_depolarization` to estimate and mitigate depolarizing noise assuming global models (`method` argument sets the explicit, detailed model).
- Added (and updated) tests according to the above changes and additions.